### PR TITLE
Fixed compilation error with PHP-5.6.0RC1

### DIFF
--- a/memcache.c
+++ b/memcache.c
@@ -1967,7 +1967,11 @@ static void php_mmc_connect (INTERNAL_FUNCTION_PARAMETERS, int persistent) /* {{
 		mmc_pool_add(pool, mmc, 1);
 
 		object_init_ex(return_value, memcache_class_entry_ptr);
+#if PHP_VERSION_ID >= 50600
+		list_id = zend_list_insert(pool, le_memcache_pool TSRMLS_CC);
+#else
 		list_id = zend_list_insert(pool, le_memcache_pool);
+#endif
 		add_property_resource(return_value, "connection", list_id);
 	}
 	else if (zend_hash_find(Z_OBJPROP_P(mmc_object), "connection", sizeof("connection"), (void **) &connection) != FAILURE) {
@@ -1984,7 +1988,11 @@ static void php_mmc_connect (INTERNAL_FUNCTION_PARAMETERS, int persistent) /* {{
 		pool = mmc_pool_new(TSRMLS_C);
 		mmc_pool_add(pool, mmc, 1);
 
+#if PHP_VERSION_ID >= 50600
+		list_id = zend_list_insert(pool, le_memcache_pool TSRMLS_CC);
+#else
 		list_id = zend_list_insert(pool, le_memcache_pool);
+#endif
 		add_property_resource(mmc_object, "connection", list_id);
 		RETURN_TRUE;
 	}
@@ -2074,7 +2082,11 @@ PHP_FUNCTION(memcache_add_server)
 	/* initialize pool if need be */
 	if (zend_hash_find(Z_OBJPROP_P(mmc_object), "connection", sizeof("connection"), (void **) &connection) == FAILURE) {
 		pool = mmc_pool_new(TSRMLS_C);
+#if PHP_VERSION_ID >= 50600
+		list_id = zend_list_insert(pool, le_memcache_pool TSRMLS_CC);
+#else
 		list_id = zend_list_insert(pool, le_memcache_pool);
+#endif
 		add_property_resource(mmc_object, "connection", list_id);
 	}
 	else {
@@ -2229,7 +2241,11 @@ mmc_t *mmc_find_persistent(char *host, int host_len, int port, int timeout, int 
 			mmc_server_free(mmc TSRMLS_CC);
 			mmc = NULL;
 		} else {
-			zend_list_insert(mmc, le_pmemcache);
+#if PHP_VERSION_ID >= 50600
+			zend_list_insert(mmc, le_pmemcache TSRMLS_CC);
+#else
+			zned_list_insert(mmc, le_pmemcache);
+#endif
 		}
 	}
 	else if (le->type != le_pmemcache || le->ptr == NULL) {
@@ -2247,7 +2263,11 @@ mmc_t *mmc_find_persistent(char *host, int host_len, int port, int timeout, int 
 			mmc = NULL;
 		}
 		else {
+#if PHP_VERSION_ID >= 50600
+			zend_list_insert(mmc, le_pmemcache TSRMLS_CC);
+#else
 			zend_list_insert(mmc, le_pmemcache);
+#endif
 		}
 	}
 	else {


### PR DESCRIPTION
fixed compilation error with PHP-5.6.0RC1, but still with some tests failure.

```
=====================================================================
TIME END 2014-06-23 15:53:07

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   45
---------------------------------------------------------------------

Number of tests :   52                52
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :   17 ( 32.7%) ( 32.7%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :   35 ( 67.3%) ( 67.3%)
---------------------------------------------------------------------
Time taken      :    7 seconds
=====================================================================

=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
memcache_delete() [tests/008.phpt]
memcache->delete() [tests/016.phpt]
memcache->addServer() [tests/019.phpt]
memcache->set()/memcache->get() with multiple keys and load balancing [tests/020.phpt]
memcache->getExtendedStats() [tests/022.phpt]
memcache_get_extended_stats() [tests/022a.phpt]
memcache->delete() with load balancing [tests/023.phpt]
memcache->increment() with load balancing [tests/025.phpt]
memcache->delete() with load balancing [tests/026.phpt]
ini_set("memcache.chunk_size") [tests/030.phpt]
memcache->addServer() adding server in failed mode [tests/031.phpt]
memcache->getServerStatus(), memcache->setServerParams() [tests/032.phpt]
memcache->getStats() with arguments [tests/034.phpt]
memcache::connect() with unix domain socket [tests/035.phpt]
ini_set('session.save_handler') [tests/036.phpt]
hash strategies and functions [tests/046.phpt]
ini_set('session.save_handler') with unix domain socket [tests/053.phpt]
=====================================================================
```
